### PR TITLE
feat(mobile view): improved on the mobile view

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,19 @@
+name: CreateRelease
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: zendesk/action-create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_schema: semantic

--- a/src/assets/icons/update_note.svg
+++ b/src/assets/icons/update_note.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="40" height="40" rx="10" fill="#423BCE"/>
+<path d="M28.25 14.7505L17.75 25.25L12.5 20.0005" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/markdown/RichEditor.jsx
+++ b/src/components/markdown/RichEditor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, useMediaQuery } from '@material-ui/core';
 import MDEditor from '@uiw/react-md-editor';
+import { MOBILE_MEDIA_WIDTH } from '../../constants';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -14,11 +15,19 @@ const useStyles = makeStyles(() => ({
 
 const RichTextEditor = ({ mdValue, setMDValue, preview }) => {
   const classes = useStyles();
+  const matches = useMediaQuery(MOBILE_MEDIA_WIDTH);
+
+  const handleEditorPreview = () => {
+    if (matches) {
+      return preview ? 'preview' : 'edit';
+    }
+    return preview ? 'preview' : 'live';
+  };
 
   return (
     <div className={classes.root}>
       <MDEditor
-        preview={preview ? 'preview' : 'live'}
+        preview={handleEditorPreview()}
         value={mdValue}
         height={500}
         onChange={setMDValue}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,3 +2,5 @@ export const webLinks = {
   DOCUMENTATION: 'https://github.com/verida/markdown-notes-demo/blob/main/README.md',
   WEBSITE: 'https://www.verida.io/'
 };
+
+export const MOBILE_MEDIA_WIDTH = '(max-width:768px)';

--- a/src/views/Editor.jsx
+++ b/src/views/Editor.jsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import RichTextEditor from '../components/markdown/RichEditor';
 import TrashIcon from '../assets/icons/Trash.svg';
 import ArrowLeft from '../assets/icons/arrow_left.svg';
-import SaveNote from '../assets/icons/new_note.svg';
+import SaveNote from '../assets/icons/update_note.svg';
 import PreviewIcon from '../assets/icons/eye.svg';
 import EditIcon from '../assets/icons/Edit.svg';
 import { browserQueries, noteActionsType } from '../utils/common.utils';
@@ -12,6 +12,7 @@ import AppSnackBar from '../components/snackbar/SnackBar';
 import markDownServices from '../api/services';
 import AppModalUi from '../components/modal/AppModal';
 import { DeleteNote } from '../components/common/editorActions';
+import { MOBILE_MEDIA_WIDTH } from '../constants';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -64,7 +65,7 @@ const useStyles = makeStyles((theme) => ({
 
 const Editor = ({ history, location }) => {
   const classes = useStyles();
-  const matches = useMediaQuery('(max-width:768px)');
+  const matches = useMediaQuery(MOBILE_MEDIA_WIDTH);
   const [snackPack, setSnackPack] = useState(false);
   const [mdValue, setMDvalue] = useState('');
   const [modalView, setModalView] = useState({


### PR DESCRIPTION
### Tasks

- [x] Use a "save" icon for saving documents (currently uses the same button as "new document")

- [x]  Make the default view for mobile be the editor only (ie, hide the preview until they press the preview button)

### Demo

https://www.loom.com/share/6924283c9272485fac90f1e2dc7d2159

Fixes #121