### PR TITLE
fix(getNotes): fixed set markdown dispatch

### DIFF
--- a/src/api/services.js
+++ b/src/api/services.js
@@ -174,8 +174,8 @@ class MarkDownServices extends EventEmitter {
     const filter = options || defaultOptions;
 
     try {
-      const response = await this.dataStore.getMany({}, filter);
-      return response || [];
+      const notes = await this.dataStore.getMany({}, filter);
+      return notes || [];
     } catch (error) {
       this.handleErrors(error);
     }

--- a/src/redux/reducers/editor/index.js
+++ b/src/redux/reducers/editor/index.js
@@ -20,7 +20,9 @@ const markdownEditor = createSlice({
   name: 'markdownEditor',
   reducers: {
     setMarkdownNotes(state, action) {
-      state.notes = action.payload;
+      if (action.payload) {
+        state.notes = action.payload;
+      }
       return state;
     },
     switchDisplay(state, action) {


### PR DESCRIPTION
I have been able to fix this issue from the setMarkdown notes dispatch action to ensure it doesn't save `undefined` instead of an array.  

#100